### PR TITLE
Escape mention names and add tests

### DIFF
--- a/lib/lita/handlers/message_router.rb
+++ b/lib/lita/handlers/message_router.rb
@@ -19,7 +19,7 @@ module Lita
       end
 
       def match(message)
-        regex = Regexp.new('^(' + config.robot_mention_names.join('|') + ') (.+)')
+        regex = /^(#{config.robot_mention_names.map { |n| Regexp.escape(n) }.join('|')})\s*(.+)/
         matches = message.match(regex)
         matches[2] if matches
       end

--- a/spec/lita/handlers/message_router_spec.rb
+++ b/spec/lita/handlers/message_router_spec.rb
@@ -1,12 +1,39 @@
 require "spec_helper"
 
 describe Lita::Handlers::MessageRouter, lita_handler: true do
-  before do
-    registry.config.handlers.message_router.robot_mention_names = ['!', '%']
+  let(:greetings) do
+    Class.new(Lita::Handler) do
+      def self.name
+        'Greetings'
+      end
+
+      route(/^hello world/, :hello, command: true)
+
+      def hello(response)
+        response.reply('hi')
+      end
+    end
   end
 
-  it 'routes correctly' do
+  before do
+    registry.register_handler(greetings)
+    registry.config.handlers.message_router.robot_mention_names = ['!', '%', '.']
+  end
+
+  it 'routes configured mention names correctly' do
     send_message('! hello world')
     send_message('% hello world')
+    expect(replies.count).to eq 2
+  end
+
+  it 'does not route unspecified mention names' do
+    send_message('/ hello world')
+    send_message('hello world')
+    expect(replies.count).to eq 0
+  end
+
+  it 'routes configured mention names containing special regex characters' do
+    send_message('.hello world')
+    expect(replies.count).to eq 1
   end
 end


### PR DESCRIPTION
I wanted to use '.' as a mention name but the previous regex wouldn't let me unless I escaped it in the config. This allows special regex characters to be used as aliases.
