### PR TITLE
Add regexp prefix matching

### DIFF
--- a/lib/lita/handlers/message_router.rb
+++ b/lib/lita/handlers/message_router.rb
@@ -18,10 +18,20 @@ module Lita
         end
       end
 
+      def route_prefix
+        @prefix ||= /^(?:#{
+          config.robot_mention_names.map do |p|
+            case p
+            when Regexp then "(?:#{p.to_s})"
+            else Regexp.escape(p.to_s)
+            end
+          end.join('|')
+          })\s*(.+)/
+      end
+
       def match(message)
-        regex = /^(#{config.robot_mention_names.map { |n| Regexp.escape(n) }.join('|')})\s*(.+)/
-        matches = message.match(regex)
-        matches[2] if matches
+        matches = message.match(route_prefix)
+        matches[-1] if matches
       end
 
       Lita.register_handler(self)

--- a/spec/lita/handlers/message_router_spec.rb
+++ b/spec/lita/handlers/message_router_spec.rb
@@ -17,18 +17,25 @@ describe Lita::Handlers::MessageRouter, lita_handler: true do
 
   before do
     registry.register_handler(greetings)
-    registry.config.handlers.message_router.robot_mention_names = ['!', '%', '.']
+    # Includes one regexp match with a sub-group to ensure that the suffix of
+    # the message is always selected for forwarding.
+    registry.config.handlers.message_router.robot_mention_names = ['!', '%', '.', /(fooba[rz])\s/i]
   end
 
   it 'routes configured mention names correctly' do
-    send_message('! hello world')
+    send_message('!hello world')
     send_message('% hello world')
-    expect(replies.count).to eq 2
+    send_message('foobar hello world')
+    send_message('FOOBAZ hello world')
+    expect(replies.count).to eq 4
   end
 
   it 'does not route unspecified mention names' do
     send_message('/ hello world')
     send_message('hello world')
+    send_message('foobat hello world')
+    send_message('foobarhello world')
+    send_message('FOOBAZhello world')
     expect(replies.count).to eq 0
   end
 


### PR DESCRIPTION
This adds support for matching on regular expressions in addition to
literal strings.

Regular expressions are slightly tedious because -- if they use capture
groups -- they make the offset of the suffix capture group unreliable.
As a result, it's necessary to select only the last capture group as
the forwarded message.

The prefix regexp is stored as an instance variable to avoid generating
it more often than is necessary.